### PR TITLE
compatibility with old subprocess.run API

### DIFF
--- a/stui/backend.py
+++ b/stui/backend.py
@@ -177,10 +177,10 @@ class Cluster(threading.Thread):
                 o = results.stdout.splitlines()
             else:
                 cmd = f"ssh {self.remote} {cmd}"
-                process = subprocess.run(cmd.split(" "), capture_output=True)
+                process = subprocess.run(cmd.split(" "), stdout=subprocess.PIPE)
                 o = process.stdout.decode("utf-8").splitlines()
         else:
-            process = subprocess.run(cmd.split(" "), capture_output=True)
+            process = subprocess.run(cmd.split(" "), stdout=subprocess.PIPE)
             o = process.stdout.decode("utf-8").splitlines()
             # TODO: for some reason lines are surrounded by quotes when not using SSH
             o = [line.strip('"') for line in o]


### PR DESCRIPTION
Hi, thanks for your nice job :)
It just wanted to add this fix this so stui can run on my cluster.
Let me know if you want anything changed.

Commit message:
subprocess.run has added support for capture_output only in
python 3.7. Even if python <=3.6 is officially out of support,
users can still encounter it on Slurm frontends, where stui
is likely to be used.