### PR TITLE
Fix "not a valid VAlign" error

### DIFF
--- a/stui/stui.py
+++ b/stui/stui.py
@@ -77,8 +77,8 @@ class StuiWidget(urwid.WidgetWrap):
             self.view,
             align="center",
             width=("relative", 40),
-            valign=("relative", 30),
-            height="pack",
+            valign="middle",
+            height=("relative", 30),
         )
 
         self.view_placeholder.original_widget = overlay
@@ -98,8 +98,8 @@ class StuiWidget(urwid.WidgetWrap):
             self.view,
             align="center",
             width=("relative", 40),
-            valign=("relative", 30),
-            height="pack",
+            valign="middle",
+            height=("relative", 30),
         )
 
         self.view_placeholder.original_widget = overlay


### PR DESCRIPTION
- fixes #18
- [Urwid 2.2.0](https://urwid.org/changelog.html#release-2-2-0) changed enums for "valign"