### PR TITLE
Limit refresh rate of job list

### DIFF
--- a/stui/backend.py
+++ b/stui/backend.py
@@ -91,7 +91,7 @@ class Job(object):
 
 
 class Cluster(threading.Thread):
-    def __init__(self, remote=None):
+    def __init__(self, remote=None, intervel=10):
         super().__init__()
 
         self.use_fabric = True
@@ -162,7 +162,7 @@ class Cluster(threading.Thread):
                     cmd = self.requests.get(block=False)
                     self._run_command(cmd)
 
-                sleep(30)
+                sleep(interval)
         except:
             # if self.remote:
             #     self.fabric_connection.close()

--- a/stui/backend.py
+++ b/stui/backend.py
@@ -91,7 +91,7 @@ class Job(object):
 
 
 class Cluster(threading.Thread):
-    def __init__(self, remote=None, intervel=10):
+    def __init__(self, remote=None, interval=10):
         super().__init__()
 
         self.use_fabric = True

--- a/stui/backend.py
+++ b/stui/backend.py
@@ -162,7 +162,7 @@ class Cluster(threading.Thread):
                     cmd = self.requests.get(block=False)
                     self._run_command(cmd)
 
-                sleep(1)
+                sleep(30)
         except:
             # if self.remote:
             #     self.fabric_connection.close()

--- a/stui/backend.py
+++ b/stui/backend.py
@@ -96,6 +96,7 @@ class Cluster(threading.Thread):
 
         self.use_fabric = True
         self.remote = remote
+        self.interval = interval
 
         self.is_ready = threading.Event()
 
@@ -162,7 +163,7 @@ class Cluster(threading.Thread):
                     cmd = self.requests.get(block=False)
                     self._run_command(cmd)
 
-                sleep(interval)
+                sleep(self.interval)
         except:
             # if self.remote:
             #     self.fabric_connection.close()

--- a/stui/cli.py
+++ b/stui/cli.py
@@ -4,6 +4,13 @@ import sys
 from stui.stui import StuiApp
 from stui import __version__
 
+def min_value_check(minimum):
+    def check(value):
+        ivalue = int(value)
+        if ivalue < minimum:
+            raise argparse.ArgumentTypeError(f"Minimum value allowed is {minimum}")
+        return ivalue
+    return check
 
 def parse_args():
     parser = argparse.ArgumentParser(description="stui")
@@ -17,7 +24,7 @@ def parse_args():
     parser.add_argument(
         "-r",
         "--refresh-interval",
-        type=int,
+        type=min_value_check(10),
         default=1,
         help="Refresh interval (in seconds) for fetching data from the cluster. (Default: 1s)",
     )

--- a/stui/stui.py
+++ b/stui/stui.py
@@ -19,8 +19,6 @@ logger_fh.setFormatter(
 )
 logger.addHandler(logger_fh)
 
-UPDATE_INTERVAL = 1
-
 
 class StuiWidget(urwid.WidgetWrap):
     def __init__(self, cluster):
@@ -139,7 +137,7 @@ class StuiApp(object):
     def __init__(self, args):
         super().__init__()
 
-        self.backend = backend.Cluster(args.ssh)
+        self.backend = backend.Cluster(args.ssh, arg.r)
         self.topmost_widget = StuiWidget(self.backend)
 
         self.loop = urwid.MainLoop(
@@ -205,4 +203,4 @@ class StuiApp(object):
         self.register_refresh()
 
     def register_refresh(self):
-        self.loop.set_alarm_in(UPDATE_INTERVAL, self.refresh_time)
+        self.loop.set_alarm_in(args.r, self.refresh_time)

--- a/stui/stui.py
+++ b/stui/stui.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 
 import urwid
+from urwid import MainLoop
 
 import stui.widgets as widgets
 from stui import backend
@@ -140,7 +141,7 @@ class StuiApp(object):
         self.backend = backend.Cluster(args.ssh, args.refresh_interval)
         self.topmost_widget = StuiWidget(self.backend)
 
-        self.loop = urwid.MainLoop(
+        self.loop = MainLoop(
             self.topmost_widget,
             self.palette,
             handle_mouse=True,

--- a/stui/stui.py
+++ b/stui/stui.py
@@ -149,9 +149,6 @@ class StuiApp(object):
             pop_ups=False,
         )
 
-        print(f"MainLoop instance: {self.loop}")
-        print(f"watch_pipe available: {'watch_pipe' in dir(self.loop)}")
-
         self.fd = self.loop.watch_pipe(self.cluster_connect_callback)
         self.backend.connect(self.fd)
 

--- a/stui/stui.py
+++ b/stui/stui.py
@@ -152,6 +152,8 @@ class StuiApp(object):
         self.fd = self.loop.watch_pipe(self.cluster_connect_callback)
         self.backend.connect(self.fd)
 
+        self.refresh_interval = args.refresh_interval
+
     def ssh_login_provided_callback(self, user, password):
         self.topmost_widget.connecting_popup()
         self.backend.connect(self.fd, user, password)
@@ -203,4 +205,4 @@ class StuiApp(object):
         self.register_refresh()
 
     def register_refresh(self):
-        self.loop.set_alarm_in(args.r, self.refresh_time)
+        self.loop.set_alarm_in(self.refresh_interval, self.refresh_time)

--- a/stui/stui.py
+++ b/stui/stui.py
@@ -3,7 +3,6 @@ import logging
 from datetime import datetime
 
 import urwid
-from urwid import MainLoop
 
 import stui.widgets as widgets
 from stui import backend
@@ -141,7 +140,7 @@ class StuiApp(object):
         self.backend = backend.Cluster(args.ssh, args.refresh_interval)
         self.topmost_widget = StuiWidget(self.backend)
 
-        self.loop = MainLoop(
+        self.loop = urwid.MainLoop(
             self.topmost_widget,
             self.palette,
             handle_mouse=True,
@@ -149,6 +148,9 @@ class StuiApp(object):
             event_loop=urwid.AsyncioEventLoop(loop=asyncio.get_event_loop()),
             pop_ups=False,
         )
+
+        logger.debug(f"MainLoop instance: {self.loop}")
+        logger.debug(f"watch_pipe available: {'watch_pipe' in dir(self.loop)}")
 
         self.fd = self.loop.watch_pipe(self.cluster_connect_callback)
         self.backend.connect(self.fd)

--- a/stui/stui.py
+++ b/stui/stui.py
@@ -137,7 +137,7 @@ class StuiApp(object):
     def __init__(self, args):
         super().__init__()
 
-        self.backend = backend.Cluster(args.ssh, arg.r)
+        self.backend = backend.Cluster(args.ssh, args.refresh_interval)
         self.topmost_widget = StuiWidget(self.backend)
 
         self.loop = urwid.MainLoop(

--- a/stui/stui.py
+++ b/stui/stui.py
@@ -155,7 +155,7 @@ class StuiApp(object):
         self.fd = self.loop.watch_pipe(self.cluster_connect_callback)
         self.backend.connect(self.fd)
 
-        self.refresh_interval = args.refresh_interval
+        self.refresh_interval = 1
 
     def ssh_login_provided_callback(self, user, password):
         self.topmost_widget.connecting_popup()

--- a/stui/stui.py
+++ b/stui/stui.py
@@ -149,8 +149,8 @@ class StuiApp(object):
             pop_ups=False,
         )
 
-        logger.debug(f"MainLoop instance: {self.loop}")
-        logger.debug(f"watch_pipe available: {'watch_pipe' in dir(self.loop)}")
+        print(f"MainLoop instance: {self.loop}")
+        print(f"watch_pipe available: {'watch_pipe' in dir(self.loop)}")
 
         self.fd = self.loop.watch_pipe(self.cluster_connect_callback)
         self.backend.connect(self.fd)


### PR DESCRIPTION
As mentioned in #15 , frequently sending `squeue` might affect cluster performance. In this PR the backend running interval of `get_jobs()` will be limited by the argument `--refresh-interval` which is set to 10 seconds in default. The front-end refresh interval remains 1 second

I also added a minimum interval check before passing command arguments to StuiApp, at the moment I set this minimum to 10 seconds.